### PR TITLE
Rename ENV from 'REGION' to 'AWS_REGION'

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ AWS Batch metrics exporter.
 ```bash
 go build -o aws_batch_exporter cmd/aws_batch_exporter.go
 # required
-export REGION= #your region
+export AWS_REGION= #your region
 ./aws_batch_exporter
 ```
 
 #### docker
 ```bash
 docker build . -t aws_batch_exporter
-docker run -d -p 8080:8080 -e REGION=<your region> aws_batch_exporter
+docker run -d -p 8080:8080 -e AWS_REGION=<your region> aws_batch_exporter
 ```
 
 ### Requirements

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func getenv(key, fallback string) string {
 
 func Run() {
 	addr := getenv("SERVER_ADDR", ":8080")
-	region := os.Getenv("REGION")
+	region := os.Getenv("AWS_REGION")
 	if len(region) == 0 {
 		log.Fatalln("region is required value. exit an application.")
 	}


### PR DESCRIPTION
- **main.go: Use AWS_REGION env instead of ENV**
- **README.md: Update docs with new update env name**

Close #4 